### PR TITLE
INT-1080 move tsconfig settings to the subrepo not to have reference errors when using the library

### DIFF
--- a/packages/repomod-engine-api/package.json
+++ b/packages/repomod-engine-api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@intuita-inc/repomod-engine-api",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"description": "",
 	"type": "module",
 	"exports": "./dist/index.js",

--- a/packages/repomod-engine-api/tsconfig.json
+++ b/packages/repomod-engine-api/tsconfig.json
@@ -8,6 +8,25 @@
 		"types": ["node", "mocha"],
 		"target": "es2015",
 		"declaration": true,
-		"outDir": "./dist"
+		"outDir": "./dist",
+		"esModuleInterop": true,
+		"forceConsistentCasingInFileNames": true,
+		"strict": true,
+		"noImplicitAny": true,
+		"strictNullChecks": true,
+		"strictFunctionTypes": true,
+		"strictBindCallApply": true,
+		"strictPropertyInitialization": true,
+		"noImplicitThis": true,
+		"useUnknownInCatchVariables": true,
+		"alwaysStrict": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noImplicitReturns": true,
+		"noFallthroughCasesInSwitch": true,
+		"noUncheckedIndexedAccess": true,
+		"noImplicitOverride": true,
+		"noPropertyAccessFromIndexSignature": true,
+		"skipLibCheck": true
 	}
 }


### PR DESCRIPTION
Without that, we will get an error message when we use this library:
```
Cannot read file '/intuita/codemod-registry/codemods/repomod-engine/node_modules/.pnpm/@intuita-inc+repomod-engine-api@1.1.1/node_modules/tsconfig.json'.
```

Because it doesn't know where ```"extends": "../../tsconfig.json",``` points to.
The ideal solution would be to anyway make the `repomod-engine` just a repo with the `repomod-engine-api`